### PR TITLE
FIX_00001: Exception when pressing "Push To Talk" Button

### DIFF
--- a/AssistIA/app/src/main/java/com/assistia/MainActivity.java
+++ b/AssistIA/app/src/main/java/com/assistia/MainActivity.java
@@ -17,6 +17,9 @@ import android.widget.Toast;
 
 import androidx.activity.EdgeToEdge;
 import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.graphics.Insets;
@@ -31,6 +34,7 @@ import com.assistia.model.AssistIAChatMessage;
 import com.assistia.model.BaseChatMessage;
 import com.assistia.model.UserChatMessage;
 import com.assistia.service.MistralAIService;
+import com.assistia.service.SpeechRecognitionService;
 import com.assistia.service.SpeechSynthesizerService;
 import com.assistia.service.mock.MockSpeechRecognitionService;
 import com.assistia.service.mock.MockSpeechSynthesizerService;
@@ -95,8 +99,10 @@ public class MainActivity extends AppCompatActivity {
 
         this.speakNowMessage = getString(R.string.speak_now);
 
-        //this.speechRecognitionService = new SpeechRecognitionService(this, this::registerForActivityResult);
-        this.speechRecognitionService = new MockSpeechRecognitionService();
+        //ActivityResultLauncher<Intent> activityLauncher =
+        //    registerForActivityResult(new StartActivityForResult(), this::processResult);
+        //this.speechRecognitionService = new SpeechRecognitionService(this, activityLauncher);
+        this.speechRecognitionService = new MockSpeechRecognitionService(this::processResult);
 
         String apiUrl = BuildConfig.ASSISTANT_SERVICE_URL;
         String apiKey = BuildConfig.ASSISTANT_SERVICE_KEY;
@@ -125,7 +131,7 @@ public class MainActivity extends AppCompatActivity {
         this.btnTapToRecord.setEnabled(false);
 
         Log.d(LOG_TAG, "startSpeechRecognition: Calling Speech Recognition Service");
-        this.speechRecognitionService.Run(this::processResult);
+        this.speechRecognitionService.Run();
     }
 
     private void processResult(ActivityResult result) {

--- a/AssistIA/app/src/main/java/com/assistia/contract/ISpeechRecognitionService.java
+++ b/AssistIA/app/src/main/java/com/assistia/contract/ISpeechRecognitionService.java
@@ -1,10 +1,5 @@
 package com.assistia.contract;
 
-import androidx.activity.result.ActivityResult;
-import androidx.activity.result.ActivityResultCallback;
-
-import java.util.function.Consumer;
-
 public interface ISpeechRecognitionService {
-    void Run(ActivityResultCallback<ActivityResult> processResult);
+    void Run();
 }

--- a/AssistIA/app/src/main/java/com/assistia/exception/GlobalExceptionHandler.java
+++ b/AssistIA/app/src/main/java/com/assistia/exception/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.assistia.exception;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import androidx.annotation.NonNull;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class GlobalExceptionHandler implements Thread.UncaughtExceptionHandler{
+
+  private Context context;
+  private StringBuilder errorMessageBuilder;
+
+
+  public GlobalExceptionHandler(Context context){
+    this.errorMessageBuilder = new StringBuilder();
+    this.context = context;
+  }
+
+  @Override
+  public void uncaughtException(@NonNull Thread t, @NonNull Throwable e) {
+
+    StringWriter stackTraceWriter = new StringWriter();
+    e.printStackTrace(new PrintWriter(stackTraceWriter));
+    errorMessageBuilder.append(stackTraceWriter.toString());
+
+    Log.e("com.assistia", errorMessageBuilder.toString(), e);
+
+    new Handler(Looper.getMainLooper()).post(() -> {
+      AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this.context)
+          .setTitle("An error occurred.")
+          .setMessage(e.getMessage())
+          .setPositiveButton("Terminate Application",
+              (dialog, which) -> dialog.dismiss());
+      alertDialogBuilder.show();
+      android.os.Process.killProcess(android.os.Process.myPid());
+    });
+
+  }
+}

--- a/AssistIA/app/src/main/java/com/assistia/exception/SpeechRecognitionServiceException.java
+++ b/AssistIA/app/src/main/java/com/assistia/exception/SpeechRecognitionServiceException.java
@@ -1,0 +1,7 @@
+package com.assistia.exception;
+
+public class SpeechRecognitionServiceException extends RuntimeException{
+  public SpeechRecognitionServiceException(String message){
+    super(message);
+  }
+}

--- a/AssistIA/app/src/main/java/com/assistia/service/SpeechRecognitionService.java
+++ b/AssistIA/app/src/main/java/com/assistia/service/SpeechRecognitionService.java
@@ -15,24 +15,24 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import com.assistia.R;
 import com.assistia.contract.ISpeechRecognitionService;
 
+import com.assistia.exception.SpeechRecognitionServiceException;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
 public class SpeechRecognitionService implements ISpeechRecognitionService {
     Context context;
-    BiFunction<StartActivityForResult,
-            ActivityResultCallback<ActivityResult>,
-            ActivityResultLauncher<Intent>> registerFunction;
+    ActivityResultLauncher<Intent> activityLauncher;
 
-    public SpeechRecognitionService(Context context, BiFunction<StartActivityForResult,
-            ActivityResultCallback<ActivityResult>,
-            ActivityResultLauncher<Intent>> registerFunction) {
+    public SpeechRecognitionService(Context context, ActivityResultLauncher<Intent> activityLauncher) {
         this.context = context;
-        this.registerFunction = registerFunction;
+        if(activityLauncher == null){
+            throw new SpeechRecognitionServiceException("activityLauncher can't be null");
+        }
+        this.activityLauncher = activityLauncher;
     }
 
     @Override
-    public void Run(ActivityResultCallback<ActivityResult> processResult) {
+    public void Run() {
         // Create Speech Recognition Intent
         Intent intent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
         intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
@@ -40,11 +40,11 @@ public class SpeechRecognitionService implements ISpeechRecognitionService {
         intent.putExtra(RecognizerIntent.EXTRA_PROMPT, this.context.getString(R.string.speak_now));
 
         //Log.d(LOG_TAG, "startSpeechRecognition: Intent created");
-        StartActivityForResult startActivityForResult = new StartActivityForResult();
-        ActivityResultLauncher<Intent> activityLauncher = registerFunction.apply(startActivityForResult, processResult);
+        //StartActivityForResult startActivityForResult = new StartActivityForResult();
+        //ActivityResultLauncher<Intent> activityLauncher = registerFunction.apply(startActivityForResult, processResult);
 
         // Launch Intent for response
-        activityLauncher.launch(intent);
+        this.activityLauncher.launch(intent);
         //Log.d(LOG_TAG, "startSpeechRecognition: Recognizer launched");
     }
 }

--- a/AssistIA/app/src/main/java/com/assistia/service/mock/MockSpeechRecognitionService.java
+++ b/AssistIA/app/src/main/java/com/assistia/service/mock/MockSpeechRecognitionService.java
@@ -1,21 +1,20 @@
 package com.assistia.service.mock;
 
 import android.app.Activity;
-import android.app.Instrumentation;
 import android.content.Intent;
 import android.net.Uri;
-
 import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultCallback;
-
 import com.assistia.contract.ISpeechRecognitionService;
-
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 
 public class MockSpeechRecognitionService implements ISpeechRecognitionService {
+    ActivityResultCallback<ActivityResult> processResult;
+    public MockSpeechRecognitionService(ActivityResultCallback<ActivityResult> processResult){
+        this.processResult = processResult;
+    }
     @Override
-    public void Run(ActivityResultCallback<ActivityResult> processResult) {
+    public void Run() {
         CompletableFuture.supplyAsync(() -> {
             try {
                 Thread.sleep(2000);
@@ -26,6 +25,6 @@ public class MockSpeechRecognitionService implements ISpeechRecognitionService {
             //intent.setData(Uri.parse("Hello!"));
             intent.setData(Uri.parse("Hello darkness, my old friend. I've come to talk with you again. Because a vision softly creeping. Left its seeds while I was sleeping"));
             return new ActivityResult(Activity.RESULT_OK, intent);
-        }).thenAccept(processResult::onActivityResult);
+        }).thenAccept(this.processResult::onActivityResult);
     }
 }


### PR DESCRIPTION
This fixes the error: 
java.lang.IllegalStateException: LifecycleOwner com.assistia.MainActivity@82016e8 is attempting to register while current state is RESUMED. LifecycleOwners must call register before they are STARTED.

Reference: 
https://developer.android.com/training/basics/intents/result?hl=es-419

Changes:
Activity launcher is now is declared in the MainActivity, and passed as parameter to SpeechRecognitionService constructor. The run() method of ISpeechRecognitionService now accepts no parameters. Added a global handler por exceptions GlobalExceptionHandler and SpeechRecognitionServiceException.